### PR TITLE
WE-3576: Update manifest security policy to allow for requests to / from lumosity

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
       },
       "default_popup": "html/popup.html"
    },
-   "content_security_policy": "script-src 'self' https://lumosity.com; object-src 'self'",
+   "content_security_policy": "script-src 'self' https://www.lumosity.com; object-src 'self'",
    "chrome_url_overrides": {
       "newtab": "html/game_play.html"
    },

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
       },
       "default_popup": "html/popup.html"
    },
+   "content_security_policy": "script-src 'self' https://lumosity.com; object-src 'self'",
    "chrome_url_overrides": {
       "newtab": "html/game_play.html"
    },


### PR DESCRIPTION
Allow scripts to run if they are from lumosity.com

JIRA: https://lumoslabs.atlassian.net/browse/WE-3576
Google CSP guidelines: https://developer.chrome.com/extensions/contentSecurityPolicy

Not sure if there's a way to launch and test this in a staging environment. No README on the extension. Let me know if I should pass the review off to someone else, @jdoconnor.