### PR TITLE
WE-3576: Fix Chrome Extension

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,20 +1,20 @@
 // hijack web requests made by chrome to remove security headers
 chrome.webRequest.onHeadersReceived.addListener(
-    function(info) {
-        var headers = info.responseHeaders;
-        for (var i=headers.length-1; i>=0; --i) {
-            var header = headers[i].name.toLowerCase();
-            if (header == 'x-frame-options' || header == 'frame-options') {
-                headers.splice(i, 1); // Remove header
-            }
-        }
-        return {responseHeaders: headers};
-    },
-    {
-        urls: [ 'https://*.lumosity.com/*' ], 
-        types: [ 'sub_frame' ]
-    },
-    ['blocking', 'responseHeaders']
+  function (info) {
+    var headers = info.responseHeaders;
+    for (var i = headers.length - 1; i >= 0; --i) {
+      var header = headers[i].name.toLowerCase();
+      if (header == 'x-frame-options' || header == 'frame-options' || header == 'content-security-policy') {
+        headers.splice(i, 1); // Remove header
+      }
+    }
+    return { responseHeaders: headers };
+  },
+  {
+    urls: ['https://*.lumosity.com/*'],
+    types: ['sub_frame']
+  },
+  ['blocking', 'responseHeaders']
 );
 
 games = [
@@ -132,7 +132,7 @@ games2 = [
     slug: 'speed-match-overdrive',
     name: 'Speed Match Overdrive'
   },
-    {
+  {
     slug: 'splitting-seeds',
     name: 'Splitting Seeds'
   },

--- a/manifest.json
+++ b/manifest.json
@@ -37,5 +37,5 @@
     ]
   },
   "update_url": "https://clients2.google.com/service/update2/crx",
-  "version": "1.6.9"
+  "version": "1.7.0"
 }


### PR DESCRIPTION
Updated the CSP removal script to include the new 'content-security-policy' header, allowing us to load the iFrame within the app. Chrome does not allow you to set a custom frame-ancestors rule for your Extension, so this kind of post-load processing is the only way to let our <iframe> sneak by.